### PR TITLE
Fix wrong branch name in GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,11 @@ name: Test
 on:
     pull_request:
         branches:
-            - "v*.*"
+            - "*.*"
             - "feature/*"
     push:
         branches:
-            - "v*.*"
+            - "*.*"
             - "feature/*"
 
 permissions:


### PR DESCRIPTION
This ensures CI runs for pull requests and pushes.