### PR TITLE
Remove parameter name usage for AutowireDatabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ class MyService
 }
 ```
 
-If you register multiple clients, you can autowire them by name + `Client` suffix:
+If you register multiple clients, you can autowire them by using the client name with a `Client` suffix as parameter
+name:
 
 ```php
 use MongoDB\Bundle\Attribute\AutowireClient;
@@ -106,6 +107,7 @@ use MongoDB\Client;
 class MyService
 {
     public function __construct(
+        // Will autowire the client with the id "second"
         private Client $secondClient,
     ) {}
 }
@@ -120,7 +122,7 @@ use MongoDB\Client;
 class MyService
 {
     public function __construct(
-       #[AutowireClient('second')]
+        #[AutowireClient('second')]
         private Client $client,
     ) {}
 }
@@ -128,8 +130,8 @@ class MyService
 
 ## Database and Collection Usage
 
-The client service provides access to databases and collections. You can access a database by calling the `selectDatabase`
-method, passing the database name and potential options:
+The client service provides access to databases and collections. You can access a database by calling the
+`selectDatabase` method, passing the database name and potential options:
 
 ```php
 use MongoDB\Client;
@@ -162,21 +164,9 @@ class MyService
 }
 ```
 
-You can also omit the `database` option if the property name matches the database name.
-In the following example the database name is `myDatabase`, inferred from the property name:
-
-```php
-use MongoDB\Bundle\Attribute\AutowireCollection;
-use MongoDB\Database;
-
-class MyService
-{
-    public function __construct(
-        #[AutowireDatabase]
-        private Database $myDatabase,
-    ) {}
-}
-```
+If you don't specify a database name in the attribute, the default database name (specified in the `default_database`
+configuration option) will be used. If you did not define a default database, the database name has to be specified in
+the attribute.
 
 If you have more than one client defined, you can also reference the client:
 
@@ -248,14 +238,15 @@ class MyService
 }
 ```
 
-By specifiying the `default_database` option in the configuration, you can omit the `database` option in the attribute:
+By specifiying the `default_database` option in the configuration, you can omit the `database` option in the
+`AutowireCollection` attribute:
 
 ```diff
 mongodb:
   clients:
     default:
       uri: '%env(MONGODB_URI)%'
-+      default_database: 'myDtabase'
++      default_database: 'myDatabase'
 ```
 
 ```php

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ mongodb:
   clients:
     default:
       uri: '%env(MONGODB_URI)%'
+      default_database: #...
       uri_options: #...
       driver_options: #...
 ```
@@ -146,7 +147,7 @@ class MyService
 }
 ```
 
-An alternative to this is using the `AutowireDatabase` attribute, referencing the database name:
+An alternative to this is using the `#[AutowireDatabase]` attribute, referencing the database name:
 
 ```php
 use MongoDB\Bundle\Attribute\AutowireDatabase;
@@ -166,13 +167,13 @@ In the following example the database name is `myDatabase`, inferred from the pr
 
 ```php
 use MongoDB\Bundle\Attribute\AutowireCollection;
-use MongoDB\Collection;
+use MongoDB\Database;
 
 class MyService
 {
     public function __construct(
-        #[AutowireCollection()]
-        private Collection $myDatabase,
+        #[AutowireDatabase]
+        private Database $myDatabase,
     ) {}
 }
 ```
@@ -193,7 +194,7 @@ class MyService
 ```
 
 To inject a collection, you can either call the `selectCollection` method on a `Client` or `Database` instance.
-For convenience, the `AutowireCollection` attribute provides a quicker alternative:
+For convenience, the `#[AutowireCollection]` attribute provides a quicker alternative:
 
 ```php
 use MongoDB\Bundle\Attribute\AutowireCollection;
@@ -230,6 +231,7 @@ class MyService
 ```
 
 If you have more than one client defined, you can also reference the client:
+
 ```php
 use MongoDB\Bundle\Attribute\AutowireCollection;
 use MongoDB\Collection;
@@ -241,6 +243,29 @@ class MyService
             database: 'myDatabase',
             client: 'second',
         )]
+        private Collection $myCollection,
+    ) {}
+}
+```
+
+By specifiying the `default_database` option in the configuration, you can omit the `database` option in the attribute:
+
+```diff
+mongodb:
+  clients:
+    default:
+      uri: '%env(MONGODB_URI)%'
++      default_database: 'myDtabase'
+```
+
+```php
+use MongoDB\Bundle\Attribute\AutowireCollection;
+use MongoDB\Collection;
+
+class MyService
+{
+    public function __construct(
+        #[AutowireCollection]
         private Collection $myCollection,
     ) {}
 }

--- a/tests/TestApplication/src/Controller/AutowireDatabaseController.php
+++ b/tests/TestApplication/src/Controller/AutowireDatabaseController.php
@@ -46,10 +46,10 @@ final class AutowireDatabaseController extends AbstractMongoDBController
     /** @see AutowireClientTest::testWithCustomClientSetViaOptions() */
     #[Route('/with-custom-client')]
     public function withCustomClient(
-        #[AutowireDatabase(client: FunctionalTestCase::CLIENT_ID_SECONDARY)]
-        Database $google,
+        #[AutowireDatabase(database: 'google', client: FunctionalTestCase::CLIENT_ID_SECONDARY)]
+        Database $database,
     ): JsonResponse {
-        $this->insertDocumentForDatabase($google, FunctionalTestCase::COLLECTION_USERS);
+        $this->insertDocumentForDatabase($database, FunctionalTestCase::COLLECTION_USERS);
 
         return new JsonResponse();
     }

--- a/tests/Unit/Attribute/AutowireDatabaseTest.php
+++ b/tests/Unit/Attribute/AutowireDatabaseTest.php
@@ -48,7 +48,7 @@ final class AutowireDatabaseTest extends TestCase
 
         $this->assertSame(Database::class, $definition->getClass());
         $this->assertEquals($autowire->value, $definition->getFactory());
-        $this->assertSame('mydb', $definition->getArgument(0));
+        $this->assertSame('%MongoDB\Client.default_database%', $definition->getArgument(0));
     }
 
     public function testDatabase(): void
@@ -98,7 +98,7 @@ final class AutowireDatabaseTest extends TestCase
 
         $this->assertSame(Database::class, $definition->getClass());
         $this->assertEquals($autowire->value, $definition->getFactory());
-        $this->assertSame('mydb', $definition->getArgument(0));
+        $this->assertSame('%mongodb.client.default.default_database%', $definition->getArgument(0));
         $this->assertSame(['foo' => 'bar'], $definition->getArgument(1));
     }
 }


### PR DESCRIPTION
As it is, there is no way to autowire the default database without explicitly specifying the name, instead it will always use the parameter name. To work around this, we remove usage of the parameter name and fall back to the default database; not specifying a `default_database` option or the `database` parameter in the `AutowireDatabase` attribute will result in an exception. We could use some magic to fall back to the parameter name if no default database was set, but I don't believe that results an improvement and only makes for more confusing rules.