### PR TITLE
Allow specifying options in AutowireDatabase and AutowireCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,20 +264,28 @@ class MyService
 }
 ```
 
-### Using a Codec
+## Specifying options
 
-To use a custom codec for a collection, you can specify the `codec` option in the `AutowireCollection` attribute. The
-codec class must implement the `MongoDB\Codec\DocumentCodec` interface. You can either pass an instance of the selected
-codec, or pass a service reference to the codec:
+When using the `AutowireDatabase` or `AutowireCollection` attributes, you can specify additional options for the
+resulting instances. You can pass the following options:
+|| Option || Accepted type ||
+| `codec` | `DocumentCodec` instance |
+| `typeMap`| `array` containing type map information |
+| `readPreference` | `MongoDB\Driver\ReadPreference` instance |
+| `writeConcern` | `MongoDB\Driver\writeConcern` instance |
+| `readConcern` | `MongoDB\Driver\ReadConcern` instance |
+
+In addition to passing an instance, you can also pass a service reference by specifying a string for the given option:
 
 ```php
 use MongoDB\Bundle\Attribute\AutowireCollection;
 use MongoDB\Collection;
+use MongoDB\Driver\ReadPreference;
 
 class MyService
 {
     public function __construct(
-        #[AutowireCollection(codec: MyCodec::class)]
+        #[AutowireCollection(codec: Codec::class, readPreference: new ReadPreference('secondary'))]
         private Collection $myCollection,
     ) {}
 }

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class MyService
 }
 ```
 
-## Database and Collection Usage
+## Database Usage
 
 The client service provides access to databases and collections. You can access a database by calling the
 `selectDatabase` method, passing the database name and potential options:
@@ -182,6 +182,8 @@ class MyService
     ) {}
 }
 ```
+
+## Collection Usage
 
 To inject a collection, you can either call the `selectCollection` method on a `Client` or `Database` instance.
 For convenience, the `#[AutowireCollection]` attribute provides a quicker alternative:
@@ -257,6 +259,25 @@ class MyService
 {
     public function __construct(
         #[AutowireCollection]
+        private Collection $myCollection,
+    ) {}
+}
+```
+
+### Using a Codec
+
+To use a custom codec for a collection, you can specify the `codec` option in the `AutowireCollection` attribute. The
+codec class must implement the `MongoDB\Codec\DocumentCodec` interface. You can either pass an instance of the selected
+codec, or pass a service reference to the codec:
+
+```php
+use MongoDB\Bundle\Attribute\AutowireCollection;
+use MongoDB\Collection;
+
+class MyService
+{
+    public function __construct(
+        #[AutowireCollection(codec: MyCodec::class)]
         private Collection $myCollection,
     ) {}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "mongodb/mongodb": "^1.16",
+        "mongodb/mongodb": "^1.17",
         "symfony/config": "^6.3 || ^7.0",
         "symfony/console": "^6.3 || ^7.0",
         "symfony/dependency-injection": "^6.3.5 || ^7.0",

--- a/src/Attribute/AutowireCollection.php
+++ b/src/Attribute/AutowireCollection.php
@@ -30,6 +30,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 use function is_string;
+use function ltrim;
 use function sprintf;
 
 /**
@@ -59,12 +60,17 @@ final class AutowireCollection extends AutowireCallable
 
     public function buildDefinition(mixed $value, ?string $type, ReflectionParameter $parameter): Definition
     {
+        $options = $this->options;
+        if (isset($options['codec']) && is_string($options['codec'])) {
+            $options['codec'] = new Reference(ltrim($options['codec'], '@'));
+        }
+
         return (new Definition(is_string($this->lazy) ? $this->lazy : ($type ?: Collection::class)))
             ->setFactory($value)
             ->setArguments([
                 $this->database ?? sprintf('%%%s.default_database%%', $this->serviceId),
                 $this->collection ?? $parameter->getName(),
-                $this->options,
+                $options,
             ])
             ->setLazy($this->lazy);
     }

--- a/src/Attribute/AutowireCollection.php
+++ b/src/Attribute/AutowireCollection.php
@@ -23,6 +23,7 @@ namespace MongoDB\Bundle\Attribute;
 use Attribute;
 use MongoDB\Bundle\DependencyInjection\MongoDBExtension;
 use MongoDB\Client;
+use MongoDB\Codec\DocumentCodec;
 use MongoDB\Collection;
 use ReflectionParameter;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
@@ -45,6 +46,7 @@ final class AutowireCollection extends AutowireCallable
         private readonly ?string $collection = null,
         private readonly ?string $database = null,
         ?string $client = null,
+        private readonly string|DocumentCodec|null $codec = null,
         private readonly array $options = [],
         bool|string $lazy = false,
     ) {
@@ -61,6 +63,10 @@ final class AutowireCollection extends AutowireCallable
     public function buildDefinition(mixed $value, ?string $type, ReflectionParameter $parameter): Definition
     {
         $options = $this->options;
+        if ($this->codec !== null) {
+            $options['codec'] = $this->codec;
+        }
+
         if (isset($options['codec']) && is_string($options['codec'])) {
             $options['codec'] = new Reference(ltrim($options['codec'], '@'));
         }

--- a/src/Attribute/AutowireCollection.php
+++ b/src/Attribute/AutowireCollection.php
@@ -70,9 +70,17 @@ final class AutowireCollection extends AutowireCallable
     {
         $options = [];
         foreach (['codec', 'typeMap', 'readPreference', 'writeConcern', 'readConcern'] as $option) {
-            if ($this->$option !== null) {
-                $options[$option] = is_string($this->$option) ? new Reference($this->$option) : $this->$option;
+            $optionValue = $this->$option;
+            if ($optionValue === null) {
+                continue;
             }
+
+            // If a string was given, it may be a service ID or parameter. Handle it accordingly
+            if (is_string($optionValue)) {
+                $optionValue = $option === 'typeMap' ? sprintf('%%%s%%', $optionValue) : new Reference($optionValue);
+            }
+
+            $options[$option] = $optionValue;
         }
 
         return (new Definition(is_string($this->lazy) ? $this->lazy : ($type ?: Collection::class)))

--- a/src/Attribute/AutowireCollection.php
+++ b/src/Attribute/AutowireCollection.php
@@ -25,6 +25,9 @@ use MongoDB\Bundle\DependencyInjection\MongoDBExtension;
 use MongoDB\Client;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Collection;
+use MongoDB\Driver\ReadConcern;
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\WriteConcern;
 use ReflectionParameter;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
 use Symfony\Component\DependencyInjection\Definition;
@@ -47,7 +50,10 @@ final class AutowireCollection extends AutowireCallable
         private readonly ?string $database = null,
         ?string $client = null,
         private readonly string|DocumentCodec|null $codec = null,
-        private readonly array $options = [],
+        private readonly string|array|null $typeMap = null,
+        private readonly string|ReadPreference|null $readPreference = null,
+        private readonly string|WriteConcern|null $writeConcern = null,
+        private readonly string|ReadConcern|null $readConcern = null,
         bool|string $lazy = false,
     ) {
         $this->serviceId = $client === null
@@ -62,13 +68,11 @@ final class AutowireCollection extends AutowireCallable
 
     public function buildDefinition(mixed $value, ?string $type, ReflectionParameter $parameter): Definition
     {
-        $options = $this->options;
-        if ($this->codec !== null) {
-            $options['codec'] = $this->codec;
-        }
-
-        if (isset($options['codec']) && is_string($options['codec'])) {
-            $options['codec'] = new Reference(ltrim($options['codec'], '@'));
+        $options = [];
+        foreach (['codec', 'typeMap', 'readPreference', 'writeConcern', 'readConcern'] as $option) {
+            if ($this->$option !== null) {
+                $options[$option] = is_string($this->$option) ? new Reference($this->$option) : $this->$option;
+            }
         }
 
         return (new Definition(is_string($this->lazy) ? $this->lazy : ($type ?: Collection::class)))

--- a/src/Attribute/AutowireDatabase.php
+++ b/src/Attribute/AutowireDatabase.php
@@ -68,9 +68,17 @@ final class AutowireDatabase extends AutowireCallable
     {
         $options = [];
         foreach (['codec', 'typeMap', 'readPreference', 'writeConcern', 'readConcern'] as $option) {
-            if ($this->$option !== null) {
-                $options[$option] = is_string($this->$option) ? new Reference($this->$option) : $this->$option;
+            $optionValue = $this->$option;
+            if ($optionValue === null) {
+                continue;
             }
+
+            // If a string was given, it may be a service ID or parameter. Handle it accordingly
+            if (is_string($optionValue)) {
+                $optionValue = $option === 'typeMap' ? sprintf('%%%s%%', $optionValue) : new Reference($optionValue);
+            }
+
+            $options[$option] = $optionValue;
         }
 
         return (new Definition(is_string($this->lazy) ? $this->lazy : ($type ?: Database::class)))

--- a/src/Attribute/AutowireDatabase.php
+++ b/src/Attribute/AutowireDatabase.php
@@ -23,7 +23,11 @@ namespace MongoDB\Bundle\Attribute;
 use Attribute;
 use MongoDB\Bundle\DependencyInjection\MongoDBExtension;
 use MongoDB\Client;
+use MongoDB\Codec\DocumentCodec;
 use MongoDB\Database;
+use MongoDB\Driver\ReadConcern;
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\WriteConcern;
 use ReflectionParameter;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
 use Symfony\Component\DependencyInjection\Definition;
@@ -43,7 +47,11 @@ final class AutowireDatabase extends AutowireCallable
     public function __construct(
         private readonly ?string $database = null,
         ?string $client = null,
-        private readonly array $options = [],
+        private readonly string|DocumentCodec|null $codec = null,
+        private readonly string|array|null $typeMap = null,
+        private readonly string|ReadPreference|null $readPreference = null,
+        private readonly string|WriteConcern|null $writeConcern = null,
+        private readonly string|ReadConcern|null $readConcern = null,
         bool|string $lazy = false,
     ) {
         $this->serviceId = $client === null
@@ -58,11 +66,18 @@ final class AutowireDatabase extends AutowireCallable
 
     public function buildDefinition(mixed $value, ?string $type, ReflectionParameter $parameter): Definition
     {
+        $options = [];
+        foreach (['codec', 'typeMap', 'readPreference', 'writeConcern', 'readConcern'] as $option) {
+            if ($this->$option !== null) {
+                $options[$option] = is_string($this->$option) ? new Reference($this->$option) : $this->$option;
+            }
+        }
+
         return (new Definition(is_string($this->lazy) ? $this->lazy : ($type ?: Database::class)))
             ->setFactory($value)
             ->setArguments([
                 $this->database ?? sprintf('%%%s.default_database%%', $this->serviceId),
-                $this->options,
+                $options,
             ])
             ->setLazy($this->lazy);
     }

--- a/tests/Unit/Attribute/AttributeTestCase.php
+++ b/tests/Unit/Attribute/AttributeTestCase.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MongoDB\Bundle\Tests\Unit\Attribute;
+
+use Generator;
+use MongoDB\BSON\Document;
+use MongoDB\Codec\DecodeIfSupported;
+use MongoDB\Codec\DocumentCodec;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Driver\ReadConcern;
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\WriteConcern;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Reference;
+
+use function sprintf;
+
+abstract class AttributeTestCase extends TestCase
+{
+    public static function provideOptions(): Generator
+    {
+        $codec = new class implements DocumentCodec {
+            use DecodeIfSupported;
+            use EncodeIfSupported;
+
+            public function canDecode($value): bool
+            {
+                return $value instanceof Document;
+            }
+
+            public function canEncode($value): bool
+            {
+                return $value instanceof Document;
+            }
+
+            public function decode($value): Document
+            {
+                return $value;
+            }
+
+            public function encode($value): Document
+            {
+                return $value;
+            }
+        };
+
+        $options = [
+            'codec' => $codec,
+            'typeMap' => ['root' => 'array'],
+            'writeConcern' => new WriteConcern(0),
+            'readConcern' => new ReadConcern('majority'),
+            'readPreference' => new ReadPreference('primary'),
+        ];
+
+        foreach ($options as $option => $value) {
+            yield sprintf('%s option: null', $option) => [
+                'attributeArguments' => [$option => null],
+                'expectedOptions' => [],
+            ];
+
+            yield sprintf('%s option: instance', $option) => [
+                'attributeArguments' => [$option => $value],
+                'expectedOptions' => [$option => $value],
+            ];
+
+            yield sprintf('%s option: reference', $option) => [
+                'attributeArguments' => [$option => sprintf('%s_service', $option)],
+                'expectedOptions' => [$option => new Reference(sprintf('%s_service', $option))],
+            ];
+        }
+    }
+}

--- a/tests/Unit/Attribute/AttributeTestCase.php
+++ b/tests/Unit/Attribute/AttributeTestCase.php
@@ -46,7 +46,6 @@ abstract class AttributeTestCase extends TestCase
 
         $options = [
             'codec' => $codec,
-            'typeMap' => ['root' => 'array'],
             'writeConcern' => new WriteConcern(0),
             'readConcern' => new ReadConcern('majority'),
             'readPreference' => new ReadPreference('primary'),
@@ -68,5 +67,21 @@ abstract class AttributeTestCase extends TestCase
                 'expectedOptions' => [$option => new Reference(sprintf('%s_service', $option))],
             ];
         }
+
+        // Type map
+        yield 'typeMap option: null' => [
+            'attributeArguments' => ['typeMap' => null],
+            'expectedOptions' => [],
+        ];
+
+        yield 'typeMap option: value' => [
+            'attributeArguments' => ['typeMap' => ['root' => 'bson']],
+            'expectedOptions' => ['typeMap' => ['root' => 'bson']],
+        ];
+
+        yield 'typeMap option: parameter' => [
+            'attributeArguments' => ['typeMap' => 'default_typeMap'],
+            'expectedOptions' => ['typeMap' => '%default_typeMap%'],
+        ];
     }
 }

--- a/tests/Unit/Attribute/AutowireCollectionTest.php
+++ b/tests/Unit/Attribute/AutowireCollectionTest.php
@@ -109,4 +109,31 @@ final class AutowireCollectionTest extends TestCase
         $this->assertSame('priceReports', $definition->getArgument(1));
         $this->assertSame(['foo' => 'bar'], $definition->getArgument(2));
     }
+
+    public function testWithCodecOption(): void
+    {
+        $autowire = new AutowireCollection(
+            database: 'mydb',
+            client: 'default',
+            options: ['foo' => 'bar', 'codec' => '@my_codec'],
+        );
+
+        $this->assertEquals([new Reference('mongodb.client.default'), 'selectCollection'], $autowire->value);
+
+        $definition = $autowire->buildDefinition(
+            value: $autowire->value,
+            type: Collection::class,
+            parameter: new ReflectionParameter(
+                static function (Collection $priceReports): void {
+                },
+                'priceReports',
+            ),
+        );
+
+        $this->assertSame(Collection::class, $definition->getClass());
+        $this->assertEquals($autowire->value, $definition->getFactory());
+        $this->assertSame('mydb', $definition->getArgument(0));
+        $this->assertSame('priceReports', $definition->getArgument(1));
+        $this->assertEquals(['foo' => 'bar', 'codec' => new Reference('my_codec')], $definition->getArgument(2));
+    }
 }


### PR DESCRIPTION
This PR removes the `options` parameter from `AutowireCollection` and `AutowireDatabase`, and instead adds arguments for all options supported by the `selectCollection` and `selectDatabase` methods. When passing a string value, it is treated as a service reference to be injected. The only exception to this is the `typeMap` parameter, where a string is treated as a parameter name since it will resolve to an array value, not a service.