### PR TITLE
Allow usage of `#[Target]` attribute for the MongoDB client

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ class MyService
 }
 ```
 
+You can also use the `#[Target]` attribute:
+
+```php
+use MongoDB\Client;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+class MyService
+{
+    public function __construct(
+        #[Target('second')]
+        private Client $client,
+    ) {}
+}
+```
+
 ## Database Usage
 
 The client service provides access to databases and collections. You can access a database by calling the

--- a/src/DependencyInjection/MongoDBExtension.php
+++ b/src/DependencyInjection/MongoDBExtension.php
@@ -78,6 +78,7 @@ final class MongoDBExtension extends Extension
 
             // Allows to autowire the client using the name
             $container->registerAliasForArgument($serviceId, Client::class, sprintf('%sClient', $client));
+            $container->registerAliasForArgument($serviceId, Client::class, $client);
         }
 
         // Register an autowiring alias for the default client

--- a/tests/Functional/Attribute/AutowireClientTest.php
+++ b/tests/Functional/Attribute/AutowireClientTest.php
@@ -53,6 +53,9 @@ final class AutowireClientTest extends FunctionalTestCase
 
         /** @see AutowireClientController::viaNamedClient() */
         yield 'via-named-client' => ['/autowire-client/via-named-client', self::CLIENT_ID_SECONDARY, self::DB_CUSTOMER_GOOGLE, self::COLLECTION_USERS];
+
+        /** @see AutowireClientController::viaTarget() */
+        yield 'via-target' => ['/autowire-client/via-target', self::CLIENT_ID_SECONDARY, self::DB_CUSTOMER_GOOGLE, self::COLLECTION_USERS];
     }
 
     /**

--- a/tests/TestApplication/src/Controller/AutowireClientController.php
+++ b/tests/TestApplication/src/Controller/AutowireClientController.php
@@ -24,6 +24,7 @@ use MongoDB\Bundle\Attribute\AutowireClient;
 use MongoDB\Bundle\Tests\Functional\Attribute\AutowireClientTest;
 use MongoDB\Bundle\Tests\Functional\FunctionalTestCase;
 use MongoDB\Client;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -65,6 +66,16 @@ final class AutowireClientController extends AbstractMongoDBController
         Client $secondaryClient,
     ): JsonResponse {
         $this->insertDocumentForClient($secondaryClient, FunctionalTestCase::DB_CUSTOMER_GOOGLE, FunctionalTestCase::COLLECTION_USERS);
+
+        return new JsonResponse();
+    }
+
+    #[Route('/via-target')]
+    public function viaTarget(
+        #[Target('secondary')]
+        Client $client,
+    ): JsonResponse {
+        $this->insertDocumentForClient($client, FunctionalTestCase::DB_CUSTOMER_GOOGLE, FunctionalTestCase::COLLECTION_USERS);
 
         return new JsonResponse();
     }


### PR DESCRIPTION
Suggested by @stof: the `#[Target]` attribute leverage the argument aliases to select a client instance.

It was introduced in Symfony 5.3: https://symfony.com/blog/new-in-symfony-5-3-service-autowiring-with-attributes

This makes the `#[AutowireClient]` attribute useless.