### PR TITLE
Use `getDatabase` and `getCollection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ class MyService
 ## Database Usage
 
 The client service provides access to databases and collections. You can access a database by calling the
-`selectDatabase` method, passing the database name and potential options:
+`getDatabase` method, passing the database name and potential options:
 
 ```php
 use MongoDB\Client;
@@ -144,7 +144,7 @@ class MyService
     public function __construct(
         Client $client,
     ) {
-        $this->database = $client->selectDatabase('myDatabase');
+        $this->database = $client->getDatabase('myDatabase');
     }
 }
 ```
@@ -185,7 +185,7 @@ class MyService
 
 ## Collection Usage
 
-To inject a collection, you can either call the `selectCollection` method on a `Client` or `Database` instance.
+To inject a collection, you can either call the `getCollection` method on a `Client` or `Database` instance.
 For convenience, the `#[AutowireCollection]` attribute provides a quicker alternative:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "mongodb/mongodb": "^1.17",
+        "mongodb/mongodb": "^1.21",
         "symfony/config": "^6.3 || ^7.0",
         "symfony/console": "^6.3 || ^7.0",
         "symfony/dependency-injection": "^6.3.5 || ^7.0",

--- a/src/Attribute/AutowireCollection.php
+++ b/src/Attribute/AutowireCollection.php
@@ -61,7 +61,7 @@ final class AutowireCollection extends AutowireCallable
             : MongoDBExtension::createClientServiceId($client);
 
         parent::__construct(
-            callable: [new Reference($this->serviceId), 'selectCollection'],
+            callable: [new Reference($this->serviceId), 'getCollection'],
             lazy: $lazy,
         );
     }

--- a/src/Attribute/AutowireDatabase.php
+++ b/src/Attribute/AutowireDatabase.php
@@ -59,7 +59,7 @@ final class AutowireDatabase extends AutowireCallable
             : MongoDBExtension::createClientServiceId($client);
 
         parent::__construct(
-            callable: [new Reference($this->serviceId), 'selectDatabase'],
+            callable: [new Reference($this->serviceId), 'getDatabase'],
             lazy: $lazy,
         );
     }

--- a/tests/Functional/DataCollector/DriverEventSubscriberTest.php
+++ b/tests/Functional/DataCollector/DriverEventSubscriberTest.php
@@ -36,7 +36,7 @@ class DriverEventSubscriberTest extends TestCase
 
     public function testCommandSucceeded(): void
     {
-        $this->getClient()->selectCollection('database1', 'collection1')->find();
+        $this->getClient()->getCollection('database1', 'collection1')->find();
 
         // The 2 events are commandStarted and commandSucceeded
         $this->assertCount(2, $this->collector->events);

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -68,9 +68,9 @@ class FunctionalTestCase extends WebTestCase
     {
         $client = self::getContainer()->get(MongoDBExtension::createClientServiceId($clientId));
         assert($client instanceof Client);
-        $db = $client->selectDatabase($database);
+        $db = $client->getDatabase($database);
         assert($db instanceof Database);
-        $collection = $db->selectCollection($collection);
+        $collection = $db->getCollection($collection);
         assert($collection instanceof Collection);
 
         $this->assertSame($expected, $collection->countDocuments());
@@ -80,7 +80,7 @@ class FunctionalTestCase extends WebTestCase
     {
         $client = self::getContainer()->get(MongoDBExtension::createClientServiceId($clientId));
         assert($client instanceof Client);
-        $db = $client->selectDatabase($database);
+        $db = $client->getDatabase($database);
         assert($db instanceof Database);
         $db->drop();
     }

--- a/tests/TestApplication/src/Controller/AbstractMongoDBController.php
+++ b/tests/TestApplication/src/Controller/AbstractMongoDBController.php
@@ -67,11 +67,11 @@ abstract class AbstractMongoDBController extends AbstractController
 
         assert($database !== null);
 
-        $db = $client->selectDatabase($database);
+        $db = $client->getDatabase($database);
         $db->drop();
 
         if (! $collection instanceof Collection) {
-            $collection = $db->selectCollection($collection);
+            $collection = $db->getCollection($collection);
         }
 
         $collection->insertOne(['foo' => 'bar']);
@@ -80,7 +80,7 @@ abstract class AbstractMongoDBController extends AbstractController
     final public function insertDocumentForDatabase(Database $database, string $collection): void
     {
         $database->drop();
-        $collection = $database->selectCollection($collection);
+        $collection = $database->getCollection($collection);
         $collection->insertOne(['foo' => 'bar']);
     }
 

--- a/tests/Unit/Attribute/AutowireCollectionTest.php
+++ b/tests/Unit/Attribute/AutowireCollectionTest.php
@@ -35,7 +35,7 @@ final class AutowireCollectionTest extends AttributeTestCase
     {
         $autowire = new AutowireCollection();
 
-        $this->assertEquals([new Reference($client = Client::class), 'selectCollection'], $autowire->value);
+        $this->assertEquals([new Reference($client = Client::class), 'getCollection'], $autowire->value);
 
         $definition = $autowire->buildDefinition(
             value: $autowire->value,
@@ -62,7 +62,7 @@ final class AutowireCollectionTest extends AttributeTestCase
             client: 'default',
         );
 
-        $this->assertEquals([new Reference('mongodb.client.default'), 'selectCollection'], $autowire->value);
+        $this->assertEquals([new Reference('mongodb.client.default'), 'getCollection'], $autowire->value);
 
         $definition = $autowire->buildDefinition(
             value: $autowire->value,
@@ -88,7 +88,7 @@ final class AutowireCollectionTest extends AttributeTestCase
             client: 'default',
         );
 
-        $this->assertEquals([new Reference('mongodb.client.default'), 'selectCollection'], $autowire->value);
+        $this->assertEquals([new Reference('mongodb.client.default'), 'getCollection'], $autowire->value);
 
         $definition = $autowire->buildDefinition(
             value: $autowire->value,

--- a/tests/Unit/Attribute/AutowireDatabaseTest.php
+++ b/tests/Unit/Attribute/AutowireDatabaseTest.php
@@ -34,7 +34,7 @@ final class AutowireDatabaseTest extends AttributeTestCase
     {
         $autowire = new AutowireDatabase();
 
-        $this->assertEquals([new Reference(Client::class), 'selectDatabase'], $autowire->value);
+        $this->assertEquals([new Reference(Client::class), 'getDatabase'], $autowire->value);
 
         $definition = $autowire->buildDefinition(
             value: $autowire->value,
@@ -58,7 +58,7 @@ final class AutowireDatabaseTest extends AttributeTestCase
             client: 'default',
         );
 
-        $this->assertEquals([new Reference('mongodb.client.default'), 'selectDatabase'], $autowire->value);
+        $this->assertEquals([new Reference('mongodb.client.default'), 'getDatabase'], $autowire->value);
 
         $definition = $autowire->buildDefinition(
             value: $autowire->value,
@@ -82,7 +82,7 @@ final class AutowireDatabaseTest extends AttributeTestCase
             client: 'default',
         );
 
-        $this->assertEquals([new Reference('mongodb.client.default'), 'selectDatabase'], $autowire->value);
+        $this->assertEquals([new Reference('mongodb.client.default'), 'getDatabase'], $autowire->value);
 
         $definition = $autowire->buildDefinition(
             value: $autowire->value,


### PR DESCRIPTION
`selectDatabase` and `selectCollection` are deprecated since 1.21

Follows
* https://github.com/mongodb/mongo-php-library/releases/tag/1.21.0